### PR TITLE
Remove inline CSS backgrounds in a code block

### DIFF
--- a/public/question.css
+++ b/public/question.css
@@ -59,6 +59,10 @@ pre {
     line-height: 1.35;
 }
 
+pre code {
+    background: none;
+}
+
 .timestamp {
     color: var(--muted-text-color);
     font-size: 0.8rem;


### PR DESCRIPTION
The lines in a `<pre>` code block may slightly overlap. Lower parts of a line can thus be obcured by the next one. This PR removes the background of `<code>` when it's inside a `<pre>` which already has the same  background color set.

Before (missing underscores and lower parts of lowercase Ys):
![before](https://opu.peklo.biz/p/23/02/13/1676309686-bae8a.png)

After:
![after](https://opu.peklo.biz/p/23/02/13/1676309699-2bb52.png)