### PR TITLE
Fix notice box styles

### DIFF
--- a/public/question.css
+++ b/public/question.css
@@ -140,6 +140,18 @@ img {
     margin-bottom: 1rem;
 }
 
+.s-notice .d-flex {
+    display: flex;
+}
+
+.s-notice .mr8 {
+    margin-right: 1rem;
+}
+
+.s-notice svg {
+    height: 1rem;
+}
+
 .answers-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
This PR adds more style to the notice box. It looks odd currently.

Before PR:

![Screenshot from 2023-03-02 20-04-43](https://user-images.githubusercontent.com/30982145/222526903-3e44a5fa-1726-464f-9d9f-db5ec26a50d9.png)

After PR:

![Screenshot from 2023-03-02 20-04-52](https://user-images.githubusercontent.com/30982145/222526932-a79eccf2-e753-4522-9ee7-97e751e06922.png)

Example taken from: https://stackoverflow.com/questions/60174/how-can-i-prevent-sql-injection-in-php?rq=1 