### PR TITLE
Add WhateverItWorks instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project is super lightweight by design. The UI is simple and the frontend i
 | [overflow.adminforge.de](https://overflow.adminforge.de/)       | Germany                          | Operated by [adminForge](https://adminforge.de/)                                                 |
 | [overflow.hostux.net](https://overflow.hostux.net/)             | France                           | Operated by [Hostux](https://hostux.net/)                                                        |
 | [overflow.projectsegfau.lt](https://overflow.projectsegfau.lt/) | United States, Luxembourg, India | Operated by [Project Segfault](https://projectsegfau.lt/)                                        |
-| [code.xbdm.fun](https://code.xbdm.fun)                          | Germany                          | Operated by [xbdm.fun](https://xbdm.fun)                                                         |
+| [code.whateveritworks.org](https://code.whateveritworks.org)    | Germany                          | Operated by [WhateverItWorks](https://github.com/WhateverItWorks)                                |
 | [overflow.fascinated.cc](https://overflow.fascinated.cc/)       | Germany                          | Operated by [fascinated.cc](https://fascinated.cc/)                                              |
 
 ## Other Instances


### PR DESCRIPTION
`code.xbdm.fun` moved to `code.whateveritworks.org`

Proofs:
- xbdm has link on their [gothub](https://gh.whateveritworks.org/xbdmhq) and [codeberg](https://codeberg.org/xbdm) profiles to WhateverItWorks organisation
- Mentioned WhateverItWorks org has link to `WhateverItWorks.org` both on [gothub](https://gh.whateveritworks.org/WhateverItWorks) and [codeberg](https://codeberg.org/WhateverItWorks)
- [AnonymousOverflow docker compose on github](https://github.com/WhateverItWorks/my-AnonymousOverflow-docker-compose) by WhateverItWorks has xbdm commits in it
- [github issue on libmedium](https://github.com/realaravinth/libmedium/issues/18) where [md.xbdm.fun](https://md.xbdm.fun) changed to [md.whateveritworks.org](https://md.whateveritworks.org/) 