### PR TITLE
Add AnonymousOverflow to question title

### DIFF
--- a/templates/question.html
+++ b/templates/question.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html data-theme="{{ .theme }}">
     <head>
-        <title>{{ .question.Title }}</title>
+        <title>{{ .question.Title }} | AnonymousOverflow</title>
         <link rel="stylesheet" href="/static/question.css" />
         <link rel="stylesheet" href="/static/syntax.css" />
         <link rel="stylesheet" href="/static/comments.css" />


### PR DESCRIPTION
This patch adds anonymousoverflow to the title of questions, making tracking anonymousoverflow through things like activitywatch easier..