### PR TITLE
fix: redirect shortened 'a' URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	r.POST("/", routes.PostHome)
 
 	r.GET("/a/:id", routes.RedirectShortenedOverflowURL)
+	r.GET("/q/:id", routes.RedirectShortenedOverflowURL)
 
 	r.GET("/questions/:id", func(c *gin.Context) {
 		// redirect user to the question with the title


### PR DESCRIPTION
This is a follow up to #50

Stackoverflow also supports links such as `https://stackoverflow.com/q/77188146`, and redirects them to `/questions/{id}`. SearXNG uses this for example (e.g. https://searx.be/search?q=!stackoverflow%20test), hence this PR is needed to properly redirect these URLs to AnonymousOverflow.