### PR TITLE
Add redirect endpoint for shortened urls with an answer id

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-var Version = "1.12.0"
+var Version = "1.12.1"

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	r.POST("/", routes.PostHome)
 
 	r.GET("/a/:id", routes.RedirectShortenedOverflowURL)
+	r.GET("/a/:id/:answerId", routes.RedirectShortenedOverflowURL)
 	r.GET("/q/:id", routes.RedirectShortenedOverflowURL)
 	r.GET("/q/:id/:answerId", routes.RedirectShortenedOverflowURL)
 


### PR DESCRIPTION
This pull request fixes the current behavior where shortened URLs such as `https://stackoverflow.com/a/48490543/446106` return a 404 page.