### PR TITLE
Set maximum width to 40rem across screen sizes

### DIFF
--- a/public/globals.css
+++ b/public/globals.css
@@ -27,10 +27,23 @@ a {
 }
 
 html {
+    margin: auto;
+    max-width: 40rem;
+}
+
+@media only screen and (max-width: calc(40rem + 2rem)) {
+    body {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}
+
+body {
+    background-color: var(--main-bg);
+    color: var(--text-color);
+    font-family: sans-serif;
+
     margin: 0;
-    padding: 0;
-    width: 100vw;
-    height: 100vh;
 }
 
 .icon {

--- a/public/home.css
+++ b/public/home.css
@@ -1,21 +1,10 @@
 body {
-    background-color: var(--main-bg);
-    font-family: sans-serif;
-
     display: flex;
-    justify-content: center;
-    align-items: center;
-
     height: 100vh;
-    width: 100vw;
-
-    margin: 0;
-
-    color: var(--text-color);
 }
 
 .container {
-    width: 40rem;
+    margin: auto;
 }
 
 .footer {
@@ -103,11 +92,4 @@ body {
 .logo {
     width: 2rem;
     height: 2rem;
-}
-
-@media screen and (max-width: 800px) {
-    body {
-        padding: 1rem;
-        box-sizing: border-box;
-    }
 }

--- a/public/question.css
+++ b/public/question.css
@@ -1,35 +1,5 @@
 body {
-    margin: 0;
-    width: 100vw;
-    height: 100vh;
-
-    overflow-x: hidden;
-
-    background-color: var(--main-bg);
-    color: var(--text-color);
-    font-family: sans-serif;
-
-    display: flex;
-    justify-content: center;
-
-    padding-left: 5rem;
-    padding-right: 5rem;
     padding-top: 2rem;
-
-    box-sizing: border-box;
-}
-
-@media (orientation: landscape) {
-    .parent {
-        max-width: 50%;
-        width: fit-content;
-    }
-}
-@media (orientation: portrait) {
-    .parent {
-        max-width: 90%;
-        width: fit-content;
-    }
 }
 
 .header {
@@ -194,11 +164,4 @@ img {
     display: flex;
     justify-content: center;
     align-items: center;
-}
-
-@media only screen and (max-width: 800px) {
-    body {
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
 }

--- a/templates/question.html
+++ b/templates/question.html
@@ -21,91 +21,89 @@
         <script defer src="/static/question.js" type="text/javascript"></script>
 </head>
     <body>
-        <div class="parent">
-            <div class="header">
-                <a href="/" class="logo-link">
-                    <img
-                        class="logo"
-                        src="/static/codecircles.webp"
-                        alt="4 circles with alternating colors between green and white"
-                    />
-                </a>
-                {{ template "themeSwitcher.html" . }}
-            </div>
-            <div class="card">
-                <div class="card-header">
-                    <h1>{{ .question.Title }}</h1>
-                    <p class="timestamp">
-                        Asked {{ .question.Timestamp }} by
-                        <a
-                            href="{{ .question.AuthorURL }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            >{{ .question.AuthorName }}</a
-                        >.
-                    </p>
-                </div>
-                <div class="card-body">{{ .question.Body }}</div>
-                <div class="card-tags">
-                    {{ range .question.Tags }}
-                        <div class="tag">{{ . }}</div>
-                    {{ end }}
-                </div>
-                {{ if .question.Comments }} {{ template "comments.html"
-                .question }} {{end}}
-            </div>
-            <hr class="post-divider" />
-            <div class="answers-header">
-                <h2>Answers</h2>
-                <div class="sorting">
-                    <form>
-                        <select name="sort_by">
-                            <option disabled value="">Sort answers by...</option>
-                            <option value="votes"{{ if eq .sortValue "votes" }} selected{{ end }}>Votes</option>
-                            <option value="trending"{{ if eq .sortValue "trending" }} selected{{ end }}>Trending</option>
-                            <option value="newest"{{ if eq .sortValue "newest" }} selected{{ end }}>Date modified (newest first)</option>
-                            <option value="oldest"{{ if eq .sortValue "oldest" }} selected{{ end }}>Date created (oldest first)</option>
-                        </select>
-                        <button type="submit">
-                            <img
-                                src="/static/icons/sort.svg"
-                                alt="Sieve icon"
-                            />
-                        </button>
-                    </form>
-                </div>
-            </div>
-            {{ range $answer := .answers }}
-            <div class="answer" id="{{ $answer.ID }}">
-                <div
-                    class="answer-meta{{ if $answer.IsAccepted }} accepted{{end}}"
-                >
-                <p>
-                    {{ if $answer.IsAccepted }} Accepted - {{ end }}
-                    {{$answer.Upvotes}} Votes
-                </p>
-                <a href="#{{ $answer.ID }}" class="answer-link">
-                    <div class="icon">
-                        <img src="/static/icons/link.svg" alt="Paperclip icon" />
-                    </div>
-                </a>
-            </div>
-                {{ $answer.Body }}
-                <div class="answer-author-parent">
-                    <div class="answer-author">
-                        Answered {{ $answer.Timestamp }} by
-                        <a
-                            href="{{ $answer.AuthorURL }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            >{{ $answer.AuthorName }}</a
-                        >
-                    </div>
-                </div>
-                {{ if $answer.Comments }} {{ template "comments.html" $answer }}
-                {{end}}
-            </div>
-            {{ end }}
+        <div class="header">
+            <a href="/" class="logo-link">
+                <img
+                    class="logo"
+                    src="/static/codecircles.webp"
+                    alt="4 circles with alternating colors between green and white"
+                />
+            </a>
+            {{ template "themeSwitcher.html" . }}
         </div>
+        <div class="card">
+            <div class="card-header">
+                <h1>{{ .question.Title }}</h1>
+                <p class="timestamp">
+                    Asked {{ .question.Timestamp }} by
+                    <a
+                        href="{{ .question.AuthorURL }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >{{ .question.AuthorName }}</a
+                    >.
+                </p>
+            </div>
+            <div class="card-body">{{ .question.Body }}</div>
+            <div class="card-tags">
+                {{ range .question.Tags }}
+                    <div class="tag">{{ . }}</div>
+                {{ end }}
+            </div>
+            {{ if .question.Comments }} {{ template "comments.html"
+            .question }} {{end}}
+        </div>
+        <hr class="post-divider" />
+        <div class="answers-header">
+            <h2>Answers</h2>
+            <div class="sorting">
+                <form>
+                    <select name="sort_by">
+                        <option disabled value="">Sort answers by...</option>
+                        <option value="votes"{{ if eq .sortValue "votes" }} selected{{ end }}>Votes</option>
+                        <option value="trending"{{ if eq .sortValue "trending" }} selected{{ end }}>Trending</option>
+                        <option value="newest"{{ if eq .sortValue "newest" }} selected{{ end }}>Date modified (newest first)</option>
+                        <option value="oldest"{{ if eq .sortValue "oldest" }} selected{{ end }}>Date created (oldest first)</option>
+                    </select>
+                    <button type="submit">
+                        <img
+                            src="/static/icons/sort.svg"
+                            alt="Sieve icon"
+                        />
+                    </button>
+                </form>
+            </div>
+        </div>
+        {{ range $answer := .answers }}
+        <div class="answer" id="{{ $answer.ID }}">
+            <div
+                class="answer-meta{{ if $answer.IsAccepted }} accepted{{end}}"
+            >
+            <p>
+                {{ if $answer.IsAccepted }} Accepted - {{ end }}
+                {{$answer.Upvotes}} Votes
+            </p>
+            <a href="#{{ $answer.ID }}" class="answer-link">
+                <div class="icon">
+                    <img src="/static/icons/link.svg" alt="Paperclip icon" />
+                </div>
+            </a>
+        </div>
+            {{ $answer.Body }}
+            <div class="answer-author-parent">
+                <div class="answer-author">
+                    Answered {{ $answer.Timestamp }} by
+                    <a
+                        href="{{ $answer.AuthorURL }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >{{ $answer.AuthorName }}</a
+                    >
+                </div>
+            </div>
+            {{ if $answer.Comments }} {{ template "comments.html" $answer }}
+            {{end}}
+        </div>
+        {{ end }}
     </body>
 </html>


### PR DESCRIPTION
Referencing GH-45: 50% is really narrow on smaller screen sizes, the maximum width should instead be calculated from the font size.

Some rules are removed to correct the bounding box size
in browser inspector and fix the overflow on the x-axis.

The now-unused div.parent is removed; please hide whitespace changes when view the diff for better clarity.