### PR TITLE
Instance domain change

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -71,9 +71,9 @@
             "operators": ["https://freedit.eu"]
         },
         {
-            "url": "https://ao.ftw.lol",
+            "url": "https://ao.rootdo.com",
             "regions": ["Germany"],
-            "operators": ["https://ftw.lol"]
+            "operators": ["https://rootdo.com"]
         },
         {
             "url": "https://anonoverflow.nirn.quest",


### PR DESCRIPTION
Related to #136

Update the server domain and operator in `instances.json` to reflect the new domain and operator.

* Change the `url` field from `https://ao.ftw.lol` to `https://ao.rootdo.com`.
* Change the `operators` field from `https://ftw.lol` to `https://rootdo.com`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/httpjamesm/AnonymousOverflow/issues/136?shareId=cc4cf1d0-7aa5-4fe4-bf79-9ef0b0640e2a).