### PR TITLE
Add theme support using environment variable

### DIFF
--- a/public/globals.css
+++ b/public/globals.css
@@ -26,6 +26,32 @@
     }
 }
 
+[data-theme="dark"] {
+    --main-bg: #1b1f26;
+    --text-color: #fff;
+    --muted-text-color: #b3b3b3;
+    --code-bg: #36383d;
+    --code-fg: #ffffff;
+    --input-bg: #2b303b;
+    --input-bg-hover: #3b404b;
+    --meta-bg: #525262;
+    --divider-color: #42464e;
+    --link-color: #92adff;
+}
+
+[data-theme="light"] {
+    --main-bg: #dbdbdb;
+    --text-color: #000;
+    --muted-text-color: #636363;
+    --code-bg: #36383d;
+    --code-fg: #ffffff;
+    --input-bg: #bcbcbc;
+    --input-bg-hover: #a8a8a8;
+    --meta-bg: #aaa8a8;
+    --divider-color: #b5b5b5;
+    --link-color: #335ad0;
+}
+
 a {
     color: var(--link-color);
 }

--- a/public/globals.css
+++ b/public/globals.css
@@ -1,9 +1,13 @@
 :root {
+    --code-bg: #36383d;
+    --code-fg: #ffffff;
+}
+
+:root,
+[data-theme="dark"] {
     --main-bg: #1b1f26;
     --text-color: #fff;
     --muted-text-color: #b3b3b3;
-    --code-bg: #36383d;
-    --code-fg: #ffffff;
     --input-bg: #2b303b;
     --input-bg-hover: #3b404b;
     --meta-bg: #525262;
@@ -12,12 +16,10 @@
 }
 
 @media (prefers-color-scheme: light) {
-    :root {
+    :root:not([data-theme="dark"]) {
         --main-bg: #dbdbdb;
         --text-color: #000;
         --muted-text-color: #636363;
-        --code-bg: #36383d;
-        --code-fg: #ffffff;
         --input-bg: #bcbcbc;
         --input-bg-hover: #a8a8a8;
         --meta-bg: #aaa8a8;
@@ -26,25 +28,10 @@
     }
 }
 
-[data-theme="dark"] {
-    --main-bg: #1b1f26;
-    --text-color: #fff;
-    --muted-text-color: #b3b3b3;
-    --code-bg: #36383d;
-    --code-fg: #ffffff;
-    --input-bg: #2b303b;
-    --input-bg-hover: #3b404b;
-    --meta-bg: #525262;
-    --divider-color: #42464e;
-    --link-color: #92adff;
-}
-
 [data-theme="light"] {
     --main-bg: #dbdbdb;
     --text-color: #000;
     --muted-text-color: #636363;
-    --code-bg: #36383d;
-    --code-fg: #ffffff;
     --input-bg: #bcbcbc;
     --input-bg-hover: #a8a8a8;
     --meta-bg: #aaa8a8;

--- a/src/routes/home.go
+++ b/src/routes/home.go
@@ -71,8 +71,10 @@ func PostHome(c *gin.Context) {
 	translated := translateUrl(body.URL)
 
 	if translated == "" {
+		theme := utils.GetThemeFromEnv()
 		c.HTML(400, "home.html", gin.H{
 			"errorMessage": "Invalid stack overflow/exchange URL",
+			"theme":        theme,
 		})
 		return
 	}

--- a/src/routes/home.go
+++ b/src/routes/home.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"anonymousoverflow/config"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -10,8 +11,13 @@ import (
 )
 
 func GetHome(c *gin.Context) {
+	theme := os.Getenv("THEME")
+	if theme == "" {
+		theme = "auto"
+	}
 	c.HTML(200, "home.html", gin.H{
 		"version": config.Version,
+		"theme":   theme,
 	})
 }
 

--- a/src/routes/home.go
+++ b/src/routes/home.go
@@ -4,7 +4,6 @@ import (
 	"anonymousoverflow/config"
 	"anonymousoverflow/src/utils"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 

--- a/src/routes/home.go
+++ b/src/routes/home.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"anonymousoverflow/config"
+	"anonymousoverflow/src/utils"
 	"fmt"
 	"os"
 	"regexp"
@@ -11,10 +12,7 @@ import (
 )
 
 func GetHome(c *gin.Context) {
-	theme := os.Getenv("THEME")
-	if theme == "" {
-		theme = "auto"
-	}
+	theme := utils.GetThemeFromEnv()
 	c.HTML(200, "home.html", gin.H{
 		"version": config.Version,
 		"theme":   theme,

--- a/src/routes/options.go
+++ b/src/routes/options.go
@@ -2,10 +2,8 @@ package routes
 
 import (
 	"anonymousoverflow/config"
+	"anonymousoverflow/src/utils"
 	"fmt"
-	"os"
-
-	"github.com/gin-gonic/gin"
 )
 
 func ChangeOptions(c *gin.Context) {
@@ -18,10 +16,7 @@ func ChangeOptions(c *gin.Context) {
 			text = "enabled"
 		}
 		c.SetCookie("disable_images", fmt.Sprintf("%t", !c.MustGet("disable_images").(bool)), 60*60*24*365*10, "/", "", false, true)
-		theme := os.Getenv("THEME")
-		if theme == "" {
-			theme = "auto"
-		}
+		theme := utils.GetThemeFromEnv()
 		c.HTML(200, "home.html", gin.H{
 			"successMessage": "Images are now " + text,
 			"version":        config.Version,

--- a/src/routes/options.go
+++ b/src/routes/options.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"anonymousoverflow/config"
 	"fmt"
+	"os"
 
 	"github.com/gin-gonic/gin"
 )
@@ -17,9 +18,14 @@ func ChangeOptions(c *gin.Context) {
 			text = "enabled"
 		}
 		c.SetCookie("disable_images", fmt.Sprintf("%t", !c.MustGet("disable_images").(bool)), 60*60*24*365*10, "/", "", false, true)
+		theme := os.Getenv("THEME")
+		if theme == "" {
+			theme = "auto"
+		}
 		c.HTML(200, "home.html", gin.H{
 			"successMessage": "Images are now " + text,
 			"version":        config.Version,
+			"theme":          theme,
 		})
 	default:
 		c.String(400, "400 Bad Request")

--- a/src/routes/options.go
+++ b/src/routes/options.go
@@ -4,6 +4,8 @@ import (
 	"anonymousoverflow/config"
 	"anonymousoverflow/src/utils"
 	"fmt"
+
+	"github.com/gin-gonic/gin"
 )
 
 func ChangeOptions(c *gin.Context) {

--- a/src/routes/question.go
+++ b/src/routes/question.go
@@ -101,10 +101,7 @@ func ViewQuestion(c *gin.Context) {
 		imagePolicy = "'self'"
 	}
 
-	theme := os.Getenv("THEME")
-	if theme == "" {
-		theme = "auto"
-	}
+	theme := utils.GetThemeFromEnv()
 
 	c.HTML(200, "question.html", gin.H{
 		"question":    newFilteredQuestion,

--- a/src/routes/question.go
+++ b/src/routes/question.go
@@ -101,6 +101,11 @@ func ViewQuestion(c *gin.Context) {
 		imagePolicy = "'self'"
 	}
 
+	theme := os.Getenv("THEME")
+	if theme == "" {
+		theme = "auto"
+	}
+
 	c.HTML(200, "question.html", gin.H{
 		"question":    newFilteredQuestion,
 		"answers":     answers,
@@ -108,6 +113,7 @@ func ViewQuestion(c *gin.Context) {
 		"currentUrl":  fmt.Sprintf("%s%s", os.Getenv("APP_URL"), c.Request.URL.Path),
 		"sortValue":   params.SoSortValue,
 		"domain":      domain,
+		"theme":       theme,
 	})
 
 }

--- a/src/utils/theme.go
+++ b/src/utils/theme.go
@@ -1,0 +1,11 @@
+package utils
+
+import "os"
+
+func GetThemeFromEnv() string {
+	theme := os.Getenv("THEME")
+	if theme == "" {
+		theme = "auto"
+	}
+	return theme
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="{{ .theme }}">
 
 <head>
     <title>AnonymousOverflow - Private frontend for StackOverflow</title>

--- a/templates/question.html
+++ b/templates/question.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="{{ .theme }}">
 
 <head>
     <title>{{ .question.Title }} | AnonymousOverflow</title>


### PR DESCRIPTION
Related to #140

Add support for theme environment variable and update theme switching logic.

* **CSS Changes**: Modify `public/globals.css` to handle the `data-theme` attribute for light and dark themes while keeping the `prefers-color-scheme` media query.
* **Home Route**: Update `src/routes/home.go` to read the `THEME` environment variable and pass it to the template.
* **Question Route**: Update `src/routes/question.go` to read the `THEME` environment variable and pass it to the template.
* **Home Template**: Modify `templates/home.html` to add a `data-theme` attribute to the `html` tag and set its value based on the `THEME` environment variable.
* **Question Template**: Modify `templates/question.html` to add a `data-theme` attribute to the `html` tag and set its value based on the `THEME` environment variable.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/httpjamesm/AnonymousOverflow/issues/140?shareId=49630512-2006-49fd-a3ea-2d06ff0e0ae2).