### PR TITLE
Add version endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,8 @@ func main() {
 
 	r.GET("/proxy", routes.GetImage)
 
+	r.GET("/version", routes.GetVersion)
+
 	soPingCheck := checks.NewPingCheck("https://stackoverflow.com", "GET", 5000, nil, nil)
 	sePingCheck := checks.NewPingCheck("https://stackexchange.com", "GET", 5000, nil, nil)
 	healthcheck.New(r, config.DefaultConfig(), []checks.Check{soPingCheck, sePingCheck})

--- a/src/routes/version.go
+++ b/src/routes/version.go
@@ -1,0 +1,10 @@
+package routes
+
+import (
+	"anonymousoverflow/config"
+	"github.com/gin-gonic/gin"
+)
+
+func GetVersion(c *gin.Context) {
+	c.String(200, config.Version)
+}


### PR DESCRIPTION
Related to #137

Add an endpoint to return the instance version as a string.

* **New file `src/routes/version.go`**:
  - Create a new file to define the version endpoint.
  - Import necessary packages.
  - Define a function `GetVersion` that returns the version as a string.

* **Modify `main.go`**:
  - Import the new version route.
  - Add a new route to the router for the version endpoint.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/httpjamesm/AnonymousOverflow/issues/137?shareId=7593fcc1-b443-4ec7-a9b2-7bd3aab16283).