### PR TITLE
Update README link to Proxy_Redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ StackOverflow has a cluttered UI that might distract you from the content you're
 
 The open-source [Libredirect](https://github.com/libredirect/libredirect) extension for Firefox and Chromium-based desktop browsers has support for redirections to AnonymousOverflow. To enable this, simply open the extension settings, click on Stack Overflow, then toggle "Enable". That's it, now Stack Overflow links will go to AnonymousOverflow.
 
-The open-source [FREEdirector](https://openuserjs.org/scripts/sjehuda/FREEdirector) user.js script for web browsers with userscript support. You can install it with a web extension like [Greasemonkey](https://greasespot.net/), [Tampermonkey](https://tampermonkey.net/) or [Violentmonkey](https://violentmonkey.github.io/). Once installed, Stack Overflow links will go to AnonymousOverflow.
+The open-source [Proxy_Redirect](https://openuserjs.org/scripts/sjehuda/Proxy_Redirect) user.js script for web browsers with userscript support. You can install it with a web extension like [Greasemonkey](https://greasespot.net/), [Tampermonkey](https://tampermonkey.net/) or [Violentmonkey](https://violentmonkey.github.io/). Once installed, Stack Overflow links will go to AnonymousOverflow.
 
 ## How it works
 


### PR DESCRIPTION
Related to #108

Update the link in the `README.md` to point to the new URL for the Proxy_Redirect user.js script.

* Change the link in the `README.md` from https://openuserjs.org/scripts/sjehuda/FREEdirector to https://openuserjs.org/scripts/sjehuda/Proxy_Redirect.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/httpjamesm/AnonymousOverflow/issues/108?shareId=09835730-90ce-48aa-a4a6-82ee6dff3874).