### PR TITLE
Instance operator change - soflow.nerdvpn.de

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -123,7 +123,7 @@
         {
             "url": "https://soflow.nerdvpn.de",
             "regions": ["Ukraine"],
-            "operators": ["https://github.com/Sommerwiesel"]
+            "operators": ["https://nerdvpn.de"]
         },
         {
             "url": "https://overflow.einfachzocken.eu/",


### PR DESCRIPTION
Related to #142

Update the operator link and name for the instance `https://soflow.nerdvpn.de` in `instances.json`.

* Change the operator link from `https://github.com/Sommerwiesel` to `https://nerdvpn.de`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/httpjamesm/AnonymousOverflow/issues/142?shareId=c6e8f03b-0968-49c5-896e-ca0380b12795).