### PR TITLE
anonoverflow.nirn.quest --> anonoverflow.hyperreal.coffee

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -76,9 +76,9 @@
             "operators": ["https://rootdo.com"]
         },
         {
-            "url": "https://anonoverflow.nirn.quest",
-            "regions": ["Canada"],
-            "operators": ["https://nirn.quest", "https://hyperreal.coffee"]
+            "url": "https://anonoverflow.hyperreal.coffee",
+            "regions": ["United States"],
+            "operators": ["https://hyperreal.coffee"]
         },
         {
             "url": "https://o.sudovanilla.org",


### PR DESCRIPTION
I previously ran an instance at anonoverflow.nirn.quest. I have renamed the domain to anonoverflow.hyperreal.coffee.