### PR TITLE
Add "word-wrap: break-word" for links

### DIFF
--- a/public/globals.css
+++ b/public/globals.css
@@ -41,6 +41,7 @@
 
 a {
     color: var(--link-color);
+    word-wrap: break-word;
 }
 
 html {


### PR DESCRIPTION
This should fix an issue with mobile layout when the link is too long and it changes the page width.

For example on this page: https://ao.bloat.cat/questions/7244321/how-do-i-update-or-sync-a-forked-repository-on-github