### PR TITLE
feat: add support for using the stackexchange API instead of scraping the HTML

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,6 +7,8 @@ services:
         environment:
             - APP_URL=https://domain.com
             - JWT_SIGNING_SECRET=secret
+            - SCRAPER=api
+            # - API_KEY=...
         ports:
             - '80:8080'
         restart: 'always'

--- a/src/routes/question.go
+++ b/src/routes/question.go
@@ -2,31 +2,19 @@ package routes
 
 import (
 	"anonymousoverflow/config"
+	"anonymousoverflow/src/scraper"
 	"anonymousoverflow/src/utils"
 	"fmt"
-	"html"
-	"html/template"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"anonymousoverflow/src/types"
-
-	"github.com/PuerkitoBio/goquery"
 	"github.com/gin-gonic/gin"
-	"github.com/go-resty/resty/v2"
 )
 
 var codeBlockRegex = regexp.MustCompile(`(?s)<pre><code>(.+?)<\/code><\/pre>`)
 var questionCodeBlockRegex = regexp.MustCompile(`(?s)<pre class=".+"><code( class=".+")?>(.+?)</code></pre>`)
-
-var soSortValues = map[string]string{
-	"votes":    "scoredesc",
-	"trending": "trending",
-	"newest":   "modifieddesc",
-	"oldest":   "createdasc",
-}
 
 func ViewQuestion(c *gin.Context) {
 
@@ -44,52 +32,17 @@ func ViewQuestion(c *gin.Context) {
 		return
 	}
 
-	domain := "stackoverflow.com"
-
-	if strings.Contains(params.Sub, ".") {
-		domain = params.Sub
-	} else if params.Sub != "" {
-		domain = fmt.Sprintf("%s.stackexchange.com", params.Sub)
+	var questionScraper scraper.QuestionsScraper
+	if strings.ToLower(os.Getenv("SCRAPER")) == "api" {
+		questionScraper = scraper.ApiScraper{ApiKey: os.Getenv("API_KEY")}
+	} else {
+		questionScraper = scraper.HtmlScraper{}
 	}
 
-	soLink := fmt.Sprintf("https://%s/questions/%s/%s?answertab=%s", domain, questionId, params.QuestionTitle, params.SoSortValue)
-
-	resp, err := fetchQuestionData(soLink)
-
-	if resp.StatusCode() != 200 {
-		c.HTML(500, "home.html", gin.H{
-			"errorMessage": fmt.Sprintf("Received a non-OK status code %d", resp.StatusCode()),
-			"version":      config.Version,
-		})
-		return
-	}
-
-	respBody := resp.String()
-
-	respBodyReader := strings.NewReader(respBody)
-
-	doc, err := goquery.NewDocumentFromReader(respBodyReader)
+	newFilteredQuestion, answers, err := questionScraper.GetQuestion(params)
 	if err != nil {
 		c.HTML(500, "home.html", gin.H{
-			"errorMessage": "Unable to parse question data",
-			"version":      config.Version,
-		})
-		return
-	}
-
-	newFilteredQuestion, err := extractQuestionData(doc, domain)
-	if err != nil {
-		c.HTML(500, "home.html", gin.H{
-			"errorMessage": "Failed to extract question data",
-			"version":      config.Version,
-		})
-		return
-	}
-
-	answers, err := extractAnswersData(doc, domain)
-	if err != nil {
-		c.HTML(500, "home.html", gin.H{
-			"errorMessage": "Failed to extract answer data",
+			"errorMessage": err,
 			"version":      config.Version,
 		})
 		return
@@ -108,22 +61,15 @@ func ViewQuestion(c *gin.Context) {
 		"answers":     answers,
 		"imagePolicy": imagePolicy,
 		"currentUrl":  fmt.Sprintf("%s%s", os.Getenv("APP_URL"), c.Request.URL.Path),
-		"sortValue":   params.SoSortValue,
-		"domain":      domain,
+		"sortValue":   params.SortValue,
+		"domain":      params.Sub,
 		"theme":       theme,
 	})
 
 }
 
-type viewQuestionInputs struct {
-	QuestionID    string
-	QuestionTitle string
-	SoSortValue   string
-	Sub           string
-}
-
 // parseAndValidateParameters consolidates the URL and query parameters into an easily-accessible struct.
-func parseAndValidateParameters(c *gin.Context) (inputs viewQuestionInputs, err error) {
+func parseAndValidateParameters(c *gin.Context) (inputs scraper.ViewQuestionInputs, err error) {
 
 	questionId := c.Param("id")
 	if _, err = strconv.Atoi(questionId); err != nil {
@@ -140,135 +86,14 @@ func parseAndValidateParameters(c *gin.Context) (inputs viewQuestionInputs, err 
 	if sortValue == "" {
 		sortValue = "votes"
 	}
-
-	soSortValue, ok := soSortValues[sortValue]
-	if !ok {
-		soSortValue = soSortValues["votes"]
-	}
-
-	inputs.SoSortValue = soSortValue
+	inputs.SortValue = sortValue
 
 	sub := c.Param("sub")
-
-	inputs.Sub = sub
+	if sub != "" {
+		inputs.Sub = strings.Split(sub, ".")[0]
+	} else {
+		inputs.Sub = "stackoverflow"
+	}
 
 	return
-}
-
-// fetchQuestionData sends the request to StackOverflow.
-func fetchQuestionData(soLink string) (resp *resty.Response, err error) {
-	client := resty.New()
-	resp, err = client.R().Get(soLink)
-	return
-}
-
-// extractQuestionData parses the HTML document and extracts question data.
-func extractQuestionData(doc *goquery.Document, domain string) (question types.FilteredQuestion, err error) {
-	// Extract the question title.
-	questionTextParent := doc.Find("h1.fs-headline1").First()
-	question.Title = strings.TrimSpace(questionTextParent.Children().First().Text())
-
-	// Extract question tags.
-	questionTags := utils.GetPostTags(doc.Find("div.post-layout").First())
-	question.Tags = questionTags
-
-	// Extract and process the question body.
-	questionBodyParent := doc.Find("div.s-prose").First()
-	questionBodyParentHTML, err := questionBodyParent.Html()
-	if err != nil {
-		return question, err
-	}
-	question.Body = template.HTML(utils.ProcessHTMLBody(questionBodyParentHTML))
-
-	// Extract the shortened body description.
-	shortenedBody := strings.TrimSpace(questionBodyParent.Text())
-	shortenedBody = strings.ReplaceAll(shortenedBody, "\n", " ")
-	if len(shortenedBody) > 50 {
-		shortenedBody = shortenedBody[:50]
-	}
-	question.ShortenedBody = shortenedBody
-
-	// Extract question comments.
-	comments := utils.FindAndReturnComments(questionBodyParentHTML, domain, doc.Find("div.post-layout").First())
-	question.Comments = comments
-
-	// Extract question timestamp and author information.
-	questionCard := doc.Find("div.postcell").First()
-	extractMetadata(questionCard, &question, domain)
-
-	return
-}
-
-// extractMetadata extracts author and timestamp information from a given selection.
-func extractMetadata(selection *goquery.Selection, question *types.FilteredQuestion, domain string) {
-	questionMetadata := selection.Find("div.user-info").First()
-	question.Timestamp = questionMetadata.Find("span.relativetime").First().Text()
-
-	questionAuthorURL := "https://" + domain
-	questionAuthor := selection.Find("div.post-signature.owner div.user-info div.user-details a").First()
-	question.AuthorName = questionAuthor.Text()
-	questionAuthorURL += questionAuthor.AttrOr("href", "")
-	question.AuthorURL = questionAuthorURL
-
-	// Determine if the question has been edited and update author details accordingly.
-	isQuestionEdited := selection.Find("a.js-gps-track").Text() == "edited"
-	if isQuestionEdited {
-		editedAuthor := questionMetadata.Find("a").Last()
-		question.AuthorName = editedAuthor.Text()
-		question.AuthorURL = "https://" + domain + editedAuthor.AttrOr("href", "")
-	}
-}
-
-// extractAnswersData parses the HTML document and extracts answers data.
-func extractAnswersData(doc *goquery.Document, domain string) ([]types.FilteredAnswer, error) {
-	var answers []types.FilteredAnswer
-
-	// Iterate over each answer block.
-	doc.Find("div.answer").Each(func(i int, s *goquery.Selection) {
-		var answer types.FilteredAnswer
-
-		answer.ID = s.AttrOr("data-answerid", "")
-
-		postLayout := s.Find("div.post-layout").First()
-
-		// Extract upvotes.
-		voteCell := postLayout.Find("div.votecell").First()
-		voteCount := html.EscapeString(voteCell.Find("div.js-vote-count").Text())
-		answer.Upvotes = voteCount
-
-		// Check if the answer is accepted.
-		answer.IsAccepted = s.HasClass("accepted-answer")
-
-		// Extract answer body and process it.
-		answerCell := postLayout.Find("div.answercell").First()
-		answerBody := answerCell.Find("div.s-prose").First()
-		answerBodyHTML, _ := answerBody.Html()
-
-		// Process code blocks within the answer.
-		processedAnswerBody := utils.ProcessHTMLBody(answerBodyHTML)
-		answer.Body = template.HTML(processedAnswerBody)
-
-		answer.Comments = utils.FindAndReturnComments(answerBodyHTML, domain, postLayout)
-
-		// Extract author information and timestamp.
-		extractAnswerAuthorInfo(s, &answer, domain)
-
-		answers = append(answers, answer)
-	})
-
-	return answers, nil
-}
-
-// extractAnswerAuthorInfo extracts the author name, URL, and timestamp from an answer block.
-// It directly mutates the answer.
-func extractAnswerAuthorInfo(selection *goquery.Selection, answer *types.FilteredAnswer, domain string) {
-	authorDetails := selection.Find("div.post-signature").Last()
-
-	authorName := html.EscapeString(authorDetails.Find("div.user-details a").First().Text())
-	authorURL := "https://" + domain + authorDetails.Find("div.user-details a").AttrOr("href", "")
-	timestamp := html.EscapeString(authorDetails.Find("span.relativetime").Text())
-
-	answer.AuthorName = authorName
-	answer.AuthorURL = authorURL
-	answer.Timestamp = timestamp
 }

--- a/src/scraper/api.go
+++ b/src/scraper/api.go
@@ -1,0 +1,239 @@
+package scraper
+
+import (
+	"anonymousoverflow/src/types"
+	"anonymousoverflow/src/utils"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+type Owner struct {
+	AccountID    int    `json:"account_id"`
+	Reputation   int    `json:"reputation"`
+	UserID       int    `json:"user_id"`
+	UserType     string `json:"user_type"`
+	ProfileImage string `json:"profile_image"`
+	DisplayName  string `json:"display_name"`
+	Link         string `json:"link"`
+}
+
+type QuestionItem struct {
+	Tags             []string `json:"tags"`
+	Owner            Owner    `json:"owner"`
+	ViewCount        int      `json:"view_count"`
+	Score            int      `json:"score"`
+	LastActivityDate int      `json:"last_activity_date"`
+	CreationDate     int      `json:"creation_date"`
+	QuestionID       int      `json:"question_id"`
+	ContentLicense   string   `json:"content_license"`
+	Link             string   `json:"link"`
+	Title            string   `json:"title"`
+	Body             string   `json:"body"`
+	IsAnswered       bool     `json:"is_answered"`
+	AcceptedAnswerID int      `json:"accepted_answer_id"`
+	AnswerCount      int      `json:"answer_count"`
+}
+
+type AnswerItem struct {
+	Owner            Owner  `json:"owner"`
+	ViewCount        int    `json:"view_count"`
+	Score            int    `json:"score"`
+	LastActivityDate int    `json:"last_activity_date"`
+	CreationDate     int    `json:"creation_date"`
+	QuestionID       int    `json:"question_id"`
+	ContentLicense   string `json:"content_license"`
+	Link             string `json:"link"`
+	Title            string `json:"title"`
+	Body             string `json:"body"`
+	IsAccepted       bool   `json:"is_accepted"`
+	AnswerID         int    `json:"answer_id"`
+}
+
+type CommentItem struct {
+	Owner          Owner  `json:"owner"`
+	Score          int    `json:"score"`
+	CreationDate   int    `json:"creation_date"`
+	PostID         int    `json:"post_id"`
+	CommentID      int    `json:"comment_id"`
+	ContentLicense string `json:"content_license"`
+	Body           string `json:"body"`
+	Edited         bool   `json:"edited"`
+}
+
+type QuestionResponse struct {
+	Results        []QuestionItem `json:"items"`
+	HasMore        bool           `json:"has_more"`
+	QuotaMax       int            `json:"quota_max"`
+	QuotaRemaining int            `json:"quota_remaining"`
+}
+
+type AnswerResponse struct {
+	Results        []AnswerItem `json:"items"`
+	HasMore        bool         `json:"has_more"`
+	QuotaMax       int          `json:"quota_max"`
+	QuotaRemaining int          `json:"quota_remaining"`
+}
+
+type CommentResponse struct {
+	Results        []CommentItem `json:"items"`
+	HasMore        bool          `json:"has_more"`
+	QuotaMax       int           `json:"quota_max"`
+	QuotaRemaining int           `json:"quota_remaining"`
+}
+
+type ApiScraper struct{ ApiKey string }
+
+const API_URL = "https://api.stackexchange.com/2.3"
+
+func (s ApiScraper) GetQuestion(params ViewQuestionInputs) (types.FilteredQuestion, []types.FilteredAnswer, error) {
+	client := resty.New()
+	if s.ApiKey != "" {
+		client.SetAuthToken(s.ApiKey)
+	}
+
+	filteredQuestion, err := getQuestionContent(client, params)
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, err
+	}
+
+	questionComments, err := getComments(client, params, []string{params.QuestionID}, "questions")
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, err
+	}
+	questionId, _ := strconv.Atoi(params.QuestionID)
+	if comments, ok := questionComments[questionId]; ok {
+		filteredQuestion.Comments = comments
+	}
+
+	filteredAnswers, err := getAnswers(client, params)
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, err
+	}
+	var answerIds []string
+	for _, filteredAnswer := range filteredAnswers {
+		answerIds = append(answerIds, filteredAnswer.ID)
+	}
+	answerComments, err := getComments(client, params, answerIds, "answers")
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, err
+	}
+	for i, filteredAnswer := range filteredAnswers {
+		answerId, _ := strconv.Atoi(filteredAnswer.ID)
+		if comments, ok := answerComments[answerId]; ok {
+			filteredAnswers[i].Comments = comments
+		}
+	}
+
+	return filteredQuestion, filteredAnswers, nil
+}
+
+func getQuestionContent(client *resty.Client, params ViewQuestionInputs) (types.FilteredQuestion, error) {
+
+	resp, err := client.R().Get(fmt.Sprintf("%s/questions/%s?site=%s&filter=withbody", API_URL, params.QuestionID, params.Sub))
+	if err != nil {
+		return types.FilteredQuestion{}, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return types.FilteredQuestion{}, fmt.Errorf("Received a non-OK status code %d", resp.StatusCode())
+	}
+
+	var questionsResp QuestionResponse
+	if err := json.Unmarshal(resp.Body(), &questionsResp); err != nil {
+		return types.FilteredQuestion{}, err
+	}
+	question := questionsResp.Results[0]
+
+	questionBody := template.HTML(utils.ProcessHTMLBody(question.Body))
+
+	// Extract the shortened body description.
+	shortenedBody := strings.TrimSpace(question.Body)
+	shortenedBody = strings.ReplaceAll(shortenedBody, "\n", " ")
+	if len(shortenedBody) > 50 {
+		shortenedBody = shortenedBody[:50]
+	}
+	return types.FilteredQuestion{
+		Title:         question.Title,
+		Body:          questionBody,
+		Timestamp:     time.Unix(int64(question.CreationDate), 0).Format(time.RFC1123),
+		AuthorName:    question.Owner.DisplayName,
+		AuthorURL:     question.Owner.Link,
+		ShortenedBody: shortenedBody,
+		Comments:      []types.FilteredComment{},
+		Tags:          question.Tags,
+	}, nil
+}
+
+func getAnswers(client *resty.Client, params ViewQuestionInputs) ([]types.FilteredAnswer, error) {
+	resp, err := client.R().Get(fmt.Sprintf("%s/questions/%s/answers?site=%s&filter=withbody&sort=%s", API_URL, params.QuestionID, params.Sub, params.SortValue))
+	if err != nil {
+		return []types.FilteredAnswer{}, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return []types.FilteredAnswer{}, fmt.Errorf("Received a non-OK status code %d", resp.StatusCode())
+	}
+
+	var answersResp AnswerResponse
+	if err := json.Unmarshal(resp.Body(), &answersResp); err != nil {
+		return []types.FilteredAnswer{}, err
+	}
+
+	var answers []types.FilteredAnswer
+	for _, answer := range answersResp.Results {
+		answers = append(answers, types.FilteredAnswer{
+			ID:         strconv.Itoa(answer.AnswerID),
+			Upvotes:    strconv.Itoa(answer.Score),
+			IsAccepted: answer.IsAccepted,
+			AuthorName: answer.Owner.DisplayName,
+			AuthorURL:  answer.Owner.Link,
+			Timestamp:  time.Unix(int64(answer.CreationDate), 0).Format(time.RFC1123),
+			Body:       template.HTML(utils.ProcessHTMLBody(answer.Body)),
+			Comments:   []types.FilteredComment{},
+		})
+	}
+
+	return answers, nil
+}
+
+func getComments(client *resty.Client, params ViewQuestionInputs, ids []string, idType string) (map[int][]types.FilteredComment, error) {
+	delimitedIds := strings.Join(ids, ";")
+	resp, err := client.R().Get(fmt.Sprintf("%s/%s/%s/comments?site=%s&filter=withbody&sort=%s", API_URL, idType, delimitedIds, params.Sub, params.SortValue))
+
+	if err != nil {
+		return map[int][]types.FilteredComment{}, err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return map[int][]types.FilteredComment{}, fmt.Errorf("Received a non-OK status code %d", resp.StatusCode())
+	}
+
+	var commentsResp CommentResponse
+	if err := json.Unmarshal(resp.Body(), &commentsResp); err != nil {
+		return map[int][]types.FilteredComment{}, err
+	}
+
+	comments := map[int][]types.FilteredComment{}
+	for _, comment := range commentsResp.Results {
+
+		filteredComment := types.FilteredComment{
+			Text:       template.HTML(utils.ProcessHTMLBody(comment.Body)),
+			Timestamp:  time.Unix(int64(comment.CreationDate), 0).Format(time.RFC1123),
+			AuthorName: comment.Owner.DisplayName,
+			AuthorURL:  comment.Owner.Link,
+			Upvotes:    strconv.Itoa(comment.Score),
+		}
+
+		if entries, ok := comments[comment.PostID]; ok {
+			comments[comment.PostID] = append(entries, filteredComment)
+		} else {
+			comments[comment.PostID] = []types.FilteredComment{filteredComment}
+		}
+	}
+
+	return comments, nil
+}

--- a/src/scraper/base.go
+++ b/src/scraper/base.go
@@ -1,0 +1,14 @@
+package scraper
+
+import "anonymousoverflow/src/types"
+
+type ViewQuestionInputs struct {
+	QuestionID    string
+	QuestionTitle string
+	SortValue     string
+	Sub           string
+}
+
+type QuestionsScraper interface {
+	GetQuestion(ViewQuestionInputs) (types.FilteredQuestion, []types.FilteredAnswer, error)
+}

--- a/src/scraper/html.go
+++ b/src/scraper/html.go
@@ -1,0 +1,184 @@
+package scraper
+
+import (
+	"anonymousoverflow/src/types"
+	"anonymousoverflow/src/utils"
+	"fmt"
+	"html"
+	"html/template"
+	"net/http"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/go-resty/resty/v2"
+)
+
+var soSortValues = map[string]string{
+	"votes":    "scoredesc",
+	"trending": "trending",
+	"newest":   "modifieddesc",
+	"oldest":   "createdasc",
+}
+
+type HtmlScraper struct{}
+
+func (s HtmlScraper) GetQuestion(params ViewQuestionInputs) (types.FilteredQuestion, []types.FilteredAnswer, error) {
+	domain := "stackoverflow.com"
+	if params.Sub != "" {
+		domain = fmt.Sprintf("%s.stackexchange.com", params.Sub)
+	}
+
+	soSortValue, ok := soSortValues[params.SortValue]
+	if !ok {
+		soSortValue = soSortValues["votes"]
+	}
+	soLink := fmt.Sprintf("https://%s/questions/%s/%s?answertab=%s", domain, params.QuestionID, params.QuestionTitle, soSortValue)
+
+	resp, err := fetchQuestionData(soLink)
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, fmt.Errorf("Received a non-OK status code %d", resp.StatusCode())
+	}
+
+	respBody := resp.String()
+
+	respBodyReader := strings.NewReader(respBody)
+
+	doc, err := goquery.NewDocumentFromReader(respBodyReader)
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, fmt.Errorf("Received a non-OK status code %d", resp.StatusCode())
+	}
+
+	newFilteredQuestion, err := extractQuestionData(doc, params.Sub)
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, fmt.Errorf("Received a non-OK status code %d", resp.StatusCode())
+	}
+
+	answers, err := extractAnswersData(doc, params.Sub)
+	if err != nil {
+		return types.FilteredQuestion{}, []types.FilteredAnswer{}, fmt.Errorf("Failed to extract answer data")
+	}
+
+	return newFilteredQuestion, answers, nil
+}
+
+// fetchQuestionData sends the request to StackOverflow.
+func fetchQuestionData(soLink string) (resp *resty.Response, err error) {
+	client := resty.New()
+	resp, err = client.R().Get(soLink)
+	return
+}
+
+// extractQuestionData parses the HTML document and extracts question data.
+func extractQuestionData(doc *goquery.Document, domain string) (question types.FilteredQuestion, err error) {
+	// Extract the question title.
+	questionTextParent := doc.Find("h1.fs-headline1").First()
+	question.Title = strings.TrimSpace(questionTextParent.Children().First().Text())
+
+	// Extract question tags.
+	questionTags := utils.GetPostTags(doc.Find("div.post-layout").First())
+	question.Tags = questionTags
+
+	// Extract and process the question body.
+	questionBodyParent := doc.Find("div.s-prose").First()
+	questionBodyParentHTML, err := questionBodyParent.Html()
+	if err != nil {
+		return question, err
+	}
+	question.Body = template.HTML(utils.ProcessHTMLBody(questionBodyParentHTML))
+
+	// Extract the shortened body description.
+	shortenedBody := strings.TrimSpace(questionBodyParent.Text())
+	shortenedBody = strings.ReplaceAll(shortenedBody, "\n", " ")
+	if len(shortenedBody) > 50 {
+		shortenedBody = shortenedBody[:50]
+	}
+	question.ShortenedBody = shortenedBody
+
+	// Extract question comments.
+	comments := utils.FindAndReturnComments(questionBodyParentHTML, domain, doc.Find("div.post-layout").First())
+	question.Comments = comments
+
+	// Extract question timestamp and author information.
+	questionCard := doc.Find("div.postcell").First()
+	extractMetadata(questionCard, &question, domain)
+
+	return
+}
+
+// extractMetadata extracts author and timestamp information from a given selection.
+func extractMetadata(selection *goquery.Selection, question *types.FilteredQuestion, domain string) {
+	questionMetadata := selection.Find("div.user-info").First()
+	question.Timestamp = questionMetadata.Find("span.relativetime").First().Text()
+
+	questionAuthorURL := "https://" + domain
+	questionAuthor := selection.Find("div.post-signature.owner div.user-info div.user-details a").First()
+	question.AuthorName = questionAuthor.Text()
+	questionAuthorURL += questionAuthor.AttrOr("href", "")
+	question.AuthorURL = questionAuthorURL
+
+	// Determine if the question has been edited and update author details accordingly.
+	isQuestionEdited := selection.Find("a.js-gps-track").Text() == "edited"
+	if isQuestionEdited {
+		editedAuthor := questionMetadata.Find("a").Last()
+		question.AuthorName = editedAuthor.Text()
+		question.AuthorURL = "https://" + domain + editedAuthor.AttrOr("href", "")
+	}
+}
+
+// extractAnswersData parses the HTML document and extracts answers data.
+func extractAnswersData(doc *goquery.Document, domain string) ([]types.FilteredAnswer, error) {
+	var answers []types.FilteredAnswer
+
+	// Iterate over each answer block.
+	doc.Find("div.answer").Each(func(i int, s *goquery.Selection) {
+		var answer types.FilteredAnswer
+
+		answer.ID = s.AttrOr("data-answerid", "")
+
+		postLayout := s.Find("div.post-layout").First()
+
+		// Extract upvotes.
+		voteCell := postLayout.Find("div.votecell").First()
+		voteCount := html.EscapeString(voteCell.Find("div.js-vote-count").Text())
+		answer.Upvotes = voteCount
+
+		// Check if the answer is accepted.
+		answer.IsAccepted = s.HasClass("accepted-answer")
+
+		// Extract answer body and process it.
+		answerCell := postLayout.Find("div.answercell").First()
+		answerBody := answerCell.Find("div.s-prose").First()
+		answerBodyHTML, _ := answerBody.Html()
+
+		// Process code blocks within the answer.
+		processedAnswerBody := utils.ProcessHTMLBody(answerBodyHTML)
+		answer.Body = template.HTML(processedAnswerBody)
+
+		answer.Comments = utils.FindAndReturnComments(answerBodyHTML, domain, postLayout)
+
+		// Extract author information and timestamp.
+		extractAnswerAuthorInfo(s, &answer, domain)
+
+		answers = append(answers, answer)
+	})
+
+	return answers, nil
+}
+
+// extractAnswerAuthorInfo extracts the author name, URL, and timestamp from an answer block.
+// It directly mutates the answer.
+func extractAnswerAuthorInfo(selection *goquery.Selection, answer *types.FilteredAnswer, domain string) {
+	authorDetails := selection.Find("div.post-signature").Last()
+
+	authorName := html.EscapeString(authorDetails.Find("div.user-details a").First().Text())
+	authorURL := "https://" + domain + authorDetails.Find("div.user-details a").AttrOr("href", "")
+	timestamp := html.EscapeString(authorDetails.Find("span.relativetime").Text())
+
+	answer.AuthorName = authorName
+	answer.AuthorURL = authorURL
+	answer.Timestamp = timestamp
+}


### PR DESCRIPTION
Hey, this adds support for using the [Stackexchange API](https://api.stackexchange.com/docs/) instead of scraping the HTML to overcome the Cloudflare issues discussed in https://github.com/httpjamesm/AnonymousOverflow/issues/175.

The Flaresolverr approach works too, but I find the API more reliable and faster to respond. You get 300 api calls per IP address per day, or 10.000 if you sign up at StackExchange and create an API key.

To use it, just run
```sh
APP_URL=localhost:8080 JWT_SIGNING_SECRET=123 SCRAPER=api go run .
```

ARM64 docker image available at `codeberg.org/bnyro/anonoverflow:latest`.

Cheers